### PR TITLE
Change URLs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-# Config file for automatic testing at travis-ci.org
+# Config file for automatic testing at travis-ci.com
 sudo: false
 language: python
 python:
@@ -31,5 +31,5 @@ script:
 #    secure: PLEASE_REPLACE_ME
 #  on:
 #    tags: true
-#    repo: AleksiNummelin/MicroInverse
+#    repo: hainegroup/MicroInverse
 #    python: 2.7

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -15,7 +15,7 @@ Types of Contributions
 Report Bugs
 ~~~~~~~~~~~
 
-Report bugs at https://github.com/AleksiNummelin/MicroInverse/issues.
+Report bugs at https://github.com/hainegroup/MicroInverse/issues.
 
 If you are reporting a bug, please include:
 
@@ -45,7 +45,7 @@ articles, and such.
 Submit Feedback
 ~~~~~~~~~~~~~~~
 
-The best way to send feedback is to file an issue at https://github.com/AleksiNummelin/MicroInverse/issues.
+The best way to send feedback is to file an issue at https://github.com/hainegroup/MicroInverse/issues.
 
 If you are proposing a feature:
 
@@ -97,7 +97,7 @@ Before you submit a pull request, check that it meets these guidelines:
 2. If the pull request adds functionality, the docs should be updated. Put
    your new functionality into a function with a docstring, and add the
    feature to the list in README.rst.
-3. Check https://travis-ci.org/AleksiNummelin/MicroInverse/pull_requests
+3. Check https://travis-ci.com/hainegroup/MicroInverse/pull_requests
    and make sure that the tests pass for all supported Python versions.
 
 Deploying

--- a/README.rst
+++ b/README.rst
@@ -6,8 +6,8 @@ MicroInverse
 .. image:: https://img.shields.io/pypi/v/MicroInverse.svg
         :target: https://pypi.python.org/pypi/MicroInverse
 
-.. image:: https://img.shields.io/travis/AleksiNummelin/MicroInverse.svg
-        :target: https://travis-ci.org/AleksiNummelin/MicroInverse
+.. image:: https://img.shields.io/travis/hainegroup/MicroInverse.svg
+        :target: https://travis-ci.com/hainegroup/MicroInverse
 
 .. image:: https://readthedocs.org/projects/microinverse/badge/?version=latest
         :target: https://MicroInverse.readthedocs.io/en/latest/?badge=latest

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -17,13 +17,13 @@ You can either clone the public repository:
 
 .. code-block:: console
 
-    $ git clone git://github.com/AleksiNummelin/MicroInverse
+    $ git clone git://github.com/hainegroup/MicroInverse
 
 Or download the `tarball`_:
 
 .. code-block:: console
 
-    $ curl  -OL https://github.com/AleksiNummelin/MicroInverse/tarball/master
+    $ curl  -OL https://github.com/hainegroup/MicroInverse/tarball/master
 
 Once you have a copy of the source, you can install it with:
 
@@ -32,8 +32,8 @@ Once you have a copy of the source, you can install it with:
     $ python setup.py install
 
 
-.. _Github repo: https://github.com/AleksiNummelin/MicroInverse
-.. _tarball: https://github.com/AleksiNummelin/MicroInverse/tarball/master
+.. _Github repo: https://github.com/hainegroup/MicroInverse
+.. _tarball: https://github.com/hainegroup/MicroInverse/tarball/master
 
 Stable release
 --------------

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
     setup_requires=setup_requirements,
     test_suite='MicroInverse/tests',
     tests_require=test_requirements,
-    url='https://github.com/AleksiNummelin/MicroInverse',
+    url='https://github.com/hainegroup/MicroInverse',
     version='0.3.0',
     zip_safe=False,
 )


### PR DESCRIPTION
I just did it for OceanSpy, so I thought I would do it for MicroInverse as well:

- Substitute AleksiNummelin/ with hainegroup/
- Substitute travis-ci.org with travis-ci.com

@AleksiNummelin the only thing left is to change the link to MicroInverse on the readthedocs website. The new repository URL should be https://github.com/hainegroup/MicroInverse.git

If everything is working, this PR should also trigger Travis!